### PR TITLE
Fix mashup loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.8.4
+
+Resolves an issue when using Thingworx 9.2.8, 9.3.3 or later that prevented the `Loaded` event from firing on cell mashups.
+
 # 2.8.2
 
 Resolves an issue that caused mashups displayed by collection views to have incorrect styling when they had spaces in their name.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "BMCollectionView",
     "packageName": "CollectionView",
     "moduleName": "CollectionView",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "description": "Requires BMCoreUI. A widget that manages a list of view elements, efficiently adding and removing them from view based on the current scroll position.",
     "thingworxServer": "http://localhost:8915",
     "thingworxUser": "Administrator",

--- a/src/BMCollectionView.runtime.ts
+++ b/src/BMCollectionView.runtime.ts
@@ -1035,7 +1035,22 @@ export class BMCollectionViewMashupCell extends BMCollectionViewCell {
 		}
 
 		// Create the data manager
-		mashup.dataMgr.loadFromMashup(mashup);
+        // As of Thingworx 9.2.8 and 9.3.3, the manager waits for a group of promises that
+        // appears to always be blank; in these cases make the promise synchronous
+        const _all = Promise.all;
+        Promise.all = function (promises) {
+            // When the promises is an empty array, fire then immediately
+            if (!promises?.length) {
+                return {
+                    then(callback) {
+                        callback([]);
+                    }
+                }
+            }
+            return _all.apply(Promise, arguments as any);
+        } as any;
+		const dataMgrLoadResult = mashup.dataMgr.loadFromMashup(mashup);
+        Promise.all = _all;
 
 		// Set to YES if this mashup update is part of an animated transition
 		let performsMashupTransition = NO;
@@ -1139,15 +1154,32 @@ export class BMCollectionViewMashupCell extends BMCollectionViewCell {
 			self.controller.setProperty('Data', self.controller.getProperty('Data'));
 			
 		};
-		
-		// Set up the parameter values
-		if (self._parameters) self._setParametersInternal();
-		if (self._globalParameters) self._setGlobalParametersInternal();
-		self._setEditingParameterInternal();
-		self._setSelectedParameterInternal();
-		
-		// Fire the MashupLoaded event to signal that loading is complete
-        mashup.fireMashupLoadedEvent();
+
+
+        // As of Thingworx 9.2.8 and 9.3.3, data manager loading is async and it is required to wait for it
+        // before firing the loaded event or setting parameters
+        if (dataMgrLoadResult instanceof Promise) {
+			dataMgrLoadResult.then(() => {
+				// Set up the parameter values
+				if (self._parameters) self._setParametersInternal();
+				if (self._globalParameters) self._setGlobalParametersInternal();
+				self._setEditingParameterInternal();
+				self._setSelectedParameterInternal();
+				
+				// Fire the MashupLoaded event to signal that loading is complete
+				mashup.fireMashupLoadedEvent();
+			});
+        }
+        else {
+			// Set up the parameter values
+			if (self._parameters) self._setParametersInternal();
+			if (self._globalParameters) self._setGlobalParametersInternal();
+			self._setEditingParameterInternal();
+			self._setSelectedParameterInternal();
+			
+			// Fire the MashupLoaded event to signal that loading is complete
+			mashup.fireMashupLoadedEvent();
+        }
 
 		if (performsMashupTransition && mashupRootView) {
 			// Layout the mashup contents prior to rendering


### PR DESCRIPTION
Resolves an issue that prevented the `Loaded` event from triggering on mashups on Thingworx 9.2.8, 9.3.3 or later.